### PR TITLE
implemented QueryStreamed method for streaming collections

### DIFF
--- a/src/DapprWire.Contracts/DatabaseSqlRunnerExtensions.cs
+++ b/src/DapprWire.Contracts/DatabaseSqlRunnerExtensions.cs
@@ -768,6 +768,63 @@ public static class DatabaseSqlRunnerExtensions
 
     #endregion
 
+    #region QueryStreamed
+
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
+
+    /// <summary>
+    /// Executes a SQL command and returns a streamed collection of results of type T.
+    /// </summary>
+    /// <typeparam name="T">The result type.</typeparam>
+    /// <param name="databaseSqlRunner">The database SQL runner instance.</param>
+    /// <param name="sql">The SQL command.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The async enumerator to stream each item asynchronously.</returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static async IAsyncEnumerable<T> QueryStreamed<T>(
+        this IDatabaseSqlRunner databaseSqlRunner,
+        string sql,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default
+    )
+    {
+        EnsureNotNull(databaseSqlRunner);
+
+        var sqlOptions = SqlOptions.None;
+        await foreach (var item in databaseSqlRunner.QueryStreamed<T>(sql, sqlOptions, ct).ConfigureAwait(false))
+            yield return item;
+    }
+
+    /// <summary>
+    /// Executes a SQL command and returns a streamed collection of results of type T.
+    /// </summary>
+    /// <typeparam name="T">The result type.</typeparam>
+    /// <param name="databaseSqlRunner">The database SQL runner instance.</param>
+    /// <param name="sql">The SQL command.</param>
+    /// <param name="parameters">The SQL command parameters.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The async enumerator to stream each item asynchronously.</returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static async IAsyncEnumerable<T> QueryStreamed<T>(
+        this IDatabaseSqlRunner databaseSqlRunner,
+        string sql,
+        object parameters,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default
+    )
+    {
+        EnsureNotNull(databaseSqlRunner);
+
+        var sqlOptions = new SqlOptions
+        {
+            Parameters = parameters
+        };
+        await foreach (var item in databaseSqlRunner.QueryStreamed<T>(sql, sqlOptions, ct))
+            yield return item;
+    }
+
+#endif
+
+    #endregion
+
     private static void EnsureNotNull(IDatabaseSqlRunner databaseSqlRunner)
     {
         if (databaseSqlRunner is null)

--- a/src/DapprWire.Contracts/IDatabaseSqlRunner.cs
+++ b/src/DapprWire.Contracts/IDatabaseSqlRunner.cs
@@ -271,6 +271,28 @@ public interface IDatabaseSqlRunner
     );
 
     #endregion
+
+    #region QueryStreamed
+
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
+
+    /// <summary>
+    /// Executes a SQL command and returns a streamed collection of results of type T.
+    /// </summary>
+    /// <typeparam name="T">The result type.</typeparam>
+    /// <param name="sql">The SQL command.</param>
+    /// <param name="sqlOptions">The SQL options.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The async enumerator to stream each item asynchronously.</returns>
+    IAsyncEnumerable<T> QueryStreamed<T>(
+        string sql,
+        SqlOptions sqlOptions,
+        CancellationToken ct = default
+    );
+
+#endif
+
+    #endregion
 }
 
 /// <summary>

--- a/src/DapprWire/DatabaseSqlRunner.cs
+++ b/src/DapprWire/DatabaseSqlRunner.cs
@@ -292,6 +292,34 @@ public abstract class DatabaseSqlRunner<TName>(
 
     #endregion
 
+    #region QueryStreamed
+
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
+
+    /// <summary>
+    /// Executes a SQL command and returns a streamed collection of results of type T.
+    /// </summary>
+    /// <typeparam name="T">The result type.</typeparam>
+    /// <param name="sql">The SQL command.</param>
+    /// <param name="sqlOptions">The SQL options.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The async enumerator to stream each item asynchronously.</returns>
+    public async IAsyncEnumerable<T> QueryStreamed<T>(
+        string sql,
+        SqlOptions sqlOptions,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default
+    )
+    {
+        await using var reader = await ExecuteReaderAsync(sql, sqlOptions, ct).ConfigureAwait(false);
+        var parser = reader.GetRowParser<T>();
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            yield return parser(reader);
+    }
+
+#endif
+
+    #endregion
+
     /// <summary>
     /// Returns a database connection, that must be open.
     /// </summary>


### PR DESCRIPTION
Implemented the `QueryStreamed` method on `IDatabaseSqlRunner` instances that allows for streaming large collections of items using `IAsyncEnumerable`. This method is only available on .NET Standard 2.1+ or .NET 5.0+ frameworks.

```cs
var productsStream = session.QueryStreamed<ProductEntity>(
    "select Id, Name from products", 
    ct
);
await foreach(var product in productsStream)
{
    // ...
}
```